### PR TITLE
Fix test: allow ignoring non-existant file when cleaning up

### DIFF
--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -388,9 +388,14 @@ class KituraTest: XCTestCase {
     }
 
     // Delete a temporary file path.
-    func removeTemporaryFilePath(_ path: String) {
+    func removeTemporaryFilePath(_ path: String, ignoreIfNotExist: Bool=false) {
         let fileURL = URL(fileURLWithPath: path)
         let fm = FileManager.default
+        if ignoreIfNotExist {
+            guard fm.fileExists(atPath: path) else {
+                return
+            }
+        }
         do {
             try fm.removeItem(at: fileURL)
         } catch {

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -271,7 +271,8 @@ final class TestServer: KituraTest, KituraTestSuite {
         // Create a temporary socket path for this server
         let socketPath = uniqueTemporaryFilePath()
         defer {
-            removeTemporaryFilePath(socketPath)
+            // on Kitura.stop(), the socket is removed
+            removeTemporaryFilePath(socketPath, ignoreIfNotExist: true)
         }
 
         let router = Router()


### PR DESCRIPTION
Fix unit tests